### PR TITLE
Add Support for SBRef, Fix Image Orientation, Timing Bugfix when not Verbose

### DIFF
--- a/dat2niix/dat2niix.m
+++ b/dat2niix/dat2niix.m
@@ -290,9 +290,9 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  
 
 if options.Verbose
-    cmdString = ['/media/myelin/brainmappers/HardDrives/1TB/dcm2niix_lnx/dcm2niix -v y -z y -f %j -o ', niftiDirectory, ' ', dicomDirectory];
+    cmdString = ['dcm2niix -v y -z y -f %j -o ', niftiDirectory, ' ', dicomDirectory];
 else
-    cmdString = ['/media/myelin/brainmappers/HardDrives/1TB/dcm2niix_lnx/dcm2niix -z y -f %j -o ', niftiDirectory, ' ', dicomDirectory];
+    cmdString = ['dcm2niix -z y -f %j -o ', niftiDirectory, ' ', dicomDirectory];
 end
 [~, STDOUT] = system(cmdString);
 if options.Verbose
@@ -472,7 +472,7 @@ end
 
 
 function dateOfVersion = checkDcm2niixVersion(options)
-        [STDERR,STDOUT] = system('/media/myelin/brainmappers/HardDrives/1TB/dcm2niix_lnx/dcm2niix -h');
+        [STDERR,STDOUT] = system('dcm2niix -h');
         if STDERR ~= 0 
             error('Could not verify dcm2niix installation.');
         end


### PR DESCRIPTION
This pull request adds support for converting SBRef images, which have an additional string in the .dat file name "SBRef."  It also fixes the image orientations so that they match the NIFTI header (the mismatch is obvious when viewing in software that display image volumes in real mm coordinates such as Connectome Workbench).  This orientation fix was tested for SBRef magnitude and phase, multi-band magnitude and phase for both AP and PA phase encoding directions and axial slices.  The orientation was verified to exactly match the NIFTI output of dcm2niix for the first echo.  Also there is a bugfix for timing when verbose is not on.  